### PR TITLE
フィールドオプションにメッセージリテラルを使えるようにした

### DIFF
--- a/src/Proto3/Suite/DotProto/Parsing.hs
+++ b/src/Proto3/Suite/DotProto/Parsing.hs
@@ -203,12 +203,18 @@ floatLit :: ProtoParser Double
 floatLit = do sign <- char '-' $> negate <|> char '+' $> id <|> pure id
               sign <$> double
 
+messageLit :: ProtoParser ()
+messageLit = braces (many (identifierName *> symbol ":" *> value *> optional (symbol ";" <|> symbol ","))) $> ()
+
 value :: ProtoParser DotProtoValue
 value = try (BoolLit              <$> bool)
     <|> try (StringLit            <$> strLit)
     <|> try (FloatLit             <$> floatLit)
     <|> try (IntLit . fromInteger <$> integer)
     <|> try (Identifier           <$> identifier)
+    -- TODO: 現在のASTではmessageを表すことはできないので一旦 0 を返す
+    <|> try (IntLit 0             <$ messageLit)
+    -- TODO: 配列
 
 ----------------------------------------
 -- types


### PR DESCRIPTION
ASTをいじると大変なので一旦パースだけして内容は無視する

## 動作確認したこと
* `(hoge).foo = {}` や `(hoge).foo = { a: 1, b: 1 }` などをコンパイルできることを確認

## herp-masterブランチについて
* 今後デフォルトブランチとして使いたい(要設定)
* 今まで使われていた `fix-codegen-qualified-v0.4.2` は古くなっているのと、upstream(https://github.com/awakesecurity/proto3-suite) に同等の内容が取り込まれたので捨てて良さそう
* https://github.com/ccycle/proto3-suite/tree/no-field-prefix ブランチはcodegenに必要なので取り込んだ