### PR TITLE
aeson2.2に対応

### DIFF
--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -99,7 +99,7 @@ library
 
   other-modules:       Turtle.Compat
 
-  build-depends:       aeson >= 1.1.1.0 && < 2.2,
+  build-depends:       aeson >= 1.1.1.0,
                        aeson-pretty,
                        attoparsec >= 0.13.0.1,
                        base >=4.8 && <5.0,
@@ -133,7 +133,8 @@ library
                        text-short >=0.1.3 && <0.2,
                        transformers >=0.4 && <0.6,
                        turtle < 1.6.0 || >= 1.6.1 && < 1.7.0,
-                       vector >=0.11 && < 0.13
+                       vector >=0.11 && < 0.13,
+                       attoparsec-aeson
   if !impl(ghc >= 8.0)
     build-depends:     semigroups >= 0.18 && < 0.20
   hs-source-dirs:      src


### PR DESCRIPTION
ghc9.6対応に対応するのに古いaesonを使い続けたくないため
aeson2.2でも2.1でもビルドできることを確認した
CI落ちてるのはforkしたリポジトリなので無視してください