### PR TITLE
依存ライブラリーのバージョン範囲を緩和 GHC 9.8 対応

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ compiler ? "ghc8107"
+{ compiler ? "ghc982"
 , enableDhall ? false
 , enableSwagger ? true
 , swaggerWrapperFormat ? false

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -2,9 +2,10 @@ args:
 
 let
   nixpkgs = builtins.fetchTarball {
-    # release: nixpkgs-23.05pre491123.261abe8a44a7
-    # commit: 261abe8a44a7e8392598d038d2e01f7b33cf26d0
-    url = "https://hydra.nixos.org/build/236149912/download/2/nixpkgs-23.05pre491123.261abe8a44a7.tar.xz";
-    sha256 = "0yhf6zbnkj3a7wfas5clli5qk4xl0cw5zq5w4fzvd724za5nb04f";
+    # from: https://hydra.nixos.org/job/nixos/release-24.05/nixpkgs.tarball
+    # build: https://hydra.nixos.org/build/262713240
+    # commit: cc54fb41d13736e92229c21627ea4f22199fee6b
+    url = "https://hydra.nixos.org/build/262713240/download/2/nixpkgs-24.05pre631579.cc54fb41d137.tar.xz";
+    sha256 = "01jgwy8ixfnl7dig5qhih34lrx2g9xpj64yr49n0lyvpwj44s475";
   };
 in import nixpkgs ({ config = { }; } // args)

--- a/nix/overlays/haskell-packages.nix
+++ b/nix/overlays/haskell-packages.nix
@@ -26,6 +26,251 @@ in {
         [ (pkgsNew.haskell.lib.packagesFromDirectory { directory = ../packages; })
 
           (haskellPackagesNew: haskellPackagesOld: {
+
+          # With nixpkgs-23.11 and ghc981, adjunctions wants hspec for testing,
+          # which causes problems.
+          adjunctions =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.adjunctions;
+
+          # With nixpkgs-23.11 and ghc981, aeson-2.1.2.1 thinks that th-abstraction is out of bounds.
+          #
+          # Also, in order to avoid the breaking change to package structure in aeson-2.2.0.0,
+          # we patch the import list of aeson-2.1.2.1.
+          #
+          # And we disable tests because explicitly specifying aeson-2.1.2.1
+          # seems to trigger a test failure, at least on GHC 9.4.8 and 9.8.1;
+          # perhaps somewhere in nixpkgs the test is suppressed and
+          # overriding the Nix definition re-enables testing?
+          #
+          #       encodeDouble:                                FAIL
+          #         *** Failed! Falsified (after 15 tests and 2 shrinks):
+          #         1.0
+          #         0.0
+          #         "\"+inf\"" /= "null"
+          #         Use --quickcheck-replay=305830 to reproduce.
+          #         Use -p '/encodeDouble/' to rerun this test only.
+          #
+          aeson =
+            pkgsNew.haskell.lib.doJailbreak
+              ( pkgsNew.haskell.lib.dontCheck
+                  ( pkgsNew.haskell.lib.appendPatches haskellPackagesOld.aeson
+                      [ ../patches/aeson-2.1.2.1.patch ] ) );
+
+          # With nixpkgs-23.11 and ghc981, atomic-write wants hspec for testing,
+          # which causes problems.
+          atomic-write =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.atomic-write;
+
+          # With nixpkgs-23.11 and ghc981, base-compat-batteries wants hspec for testing,
+          # which causes problems.
+          base-compat-batteries =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.base-compat-batteries;
+
+          # With nixpkgs-23.11 and ghc981, base-orphans wants hspec for testing,
+          # which causes problems.
+          base-orphans =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.base-orphans;
+
+          # With nixpkgs-23.11 and ghc981, bifunctors wants hspec for testing,
+          # which causes problems.
+          bifunctors =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.bifunctors;
+
+          # With nixpkgs-23.11 and ghc981, conduit wants hspec for testing,
+          # which causes problems.
+          conduit =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.conduit;
+
+          # With nixpkgs-23.11 and ghc981, constraints wants hspec for testing,
+          # which causes problems.
+          constraints =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.constraints;
+
+          # With nixpkgs-23.11 and ghc981, data-diverse wants hspec for testing,
+          # which causes problems.
+          data-diverse =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.data-diverse;
+
+          # With nixpkgs-23.11 and ghc981, distribution-nixpkgs wants hspec for testing,
+          # which causes problems.
+          distribution-nixpkgs =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.distribution-nixpkgs;
+
+          # With nixpkgs-23.11 and ghc981, distributive wants hspec for testing,
+          # which causes problems.
+          distributive =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.distributive;
+
+          # With ghc981, doctest-0.22.2 complains about the version of the base
+          # package and depends on hspec for testing, which causes problems.
+          doctest =
+            pkgsNew.haskell.lib.dontCheck
+              (pkgsNew.haskell.lib.doJailbreak haskellPackagesOld.doctest);
+
+          # With nixpkgs-23.11 and ghc981, generic-deriving wants hspec for testing,
+          # which causes problems.  Also, it generic-deriving thinks that
+          # th-abstraction is out of bounds.
+          generic-deriving =
+            pkgsNew.haskell.lib.dontCheck
+              (pkgsNew.haskell.lib.doJailbreak haskellPackagesOld.generic-deriving);
+
+          # With nixpkgs-23.11 and ghc981, half thinks that deepseq is out of bounds.
+          half =
+            pkgsNew.haskell.lib.doJailbreak haskellPackagesOld.half;
+
+          # With nixpkgs-24.05 and ghc982, we observed a non-reproducible
+          # failure of the hedgehog tests.  Rather than risk occasional
+          # failures building this test dependency, we skip its tests.
+          hedgehog =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.hedgehog;
+
+          # With nixpkgs-23.11 and ghc981, hourglass does not support the version
+          # of the time package that is provided, but that matters only to tests.
+          hourglass =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.hourglass;
+
+          # With nixpkgs-23.11 and ghc981, hpack-0.36.0 wants hspec for testing,
+          # which causes problems.
+          hpack =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.hpack;
+
+          # With nixpkgs-23.11 and ghc981, http-types wants hspec for testing,
+          # which causes problems.
+          http-types =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.http-types;
+
+          # With nixpkgs-23.11 and ghc981, infer-license wants hspec for testing,
+          # which causes problems.
+          infer-license =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.infer-license;
+
+          # With nixpkgs-23.11 and our overrides, insert-ordered-containers thinks that lens is out of bounds.
+          insert-ordered-containers =
+            pkgsNew.haskell.lib.doJailbreak haskellPackagesOld.insert-ordered-containers;
+
+          # With nixpkgs-23.11 and ghc981, invariant indirectly depends on hspec for testing,
+          # which causes problems. Also, it generic-deriving thinks that
+          # th-abstraction is out of bounds.
+          invariant =
+            pkgsNew.haskell.lib.dontCheck
+              (pkgsNew.haskell.lib.doJailbreak haskellPackagesOld.invariant);
+
+          # With nixpkgs-23.11 and ghc981, iproute wants hspec for testing,
+          # which causes problems.
+          iproute =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.iproute;
+
+          # With nixpkgs-23.11 and ghc962, generics-sop-0.5.1.4 thinks that th-abstraction is out of bounds.
+          generics-sop =
+            pkgsNew.haskell.lib.doJailbreak haskellPackagesOld.generics-sop;
+
+          # With nixpkgs-23.11 and ghc902, large-generics thinks that primitive is out of bounds.
+          large-generics =
+            pkgsNew.haskell.lib.doJailbreak haskellPackagesOld.large-generics;
+
+          # With nixpkgs-23.11 and ghc902, large-records thinks that primitive is out of bounds.
+          large-records =
+            pkgsNew.haskell.lib.doJailbreak haskellPackagesOld.large-records;
+
+          # With nixpkgs-23.11 and ghc981 (or perhaps our customized dependencies),
+          # the tests in lifted-base fail.
+          lifted-base =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.lifted-base;
+
+          # With nixpkgs-23.11 and ghc981, monad-par wants test-framework for testing, which
+          # wants language-haskell-extract, which does not support modern template-haskell.
+          monad-par =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.monad-par;
+
+          # With nixpkgs-23.11 and ghc981, mono-traversable wants hspec for testing,
+          # which causes problems.
+          mono-traversable =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.mono-traversable;
+
+          # With nixpkgs-23.11 and our overrides, neat-interpolation that rebase is out of bounds.
+          neat-interpolation =
+            pkgsNew.haskell.lib.doJailbreak haskellPackagesOld.neat-interpolation;
+
+          # With GHC 9.0/9.2, "network-uri" with testing enabled would find that
+          # "th-compat" wants an older version of "directory" than does "process".
+          network-uri =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.network-uri;
+
+          # With nixpkgs-23.11 and our overrides, rerebase that rebase is out of bounds.
+          rerebase =
+            pkgsNew.haskell.lib.doJailbreak haskellPackagesOld.rerebase;
+
+          # With nixpkgs-23.11 and ghc981, safe-exceptions wants hspec for testing,
+          # which causes problems.
+          safe-exceptions =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.safe-exceptions;
+
+          # With nixpkgs-23.11 and ghc981, streaming-commons wants hspec for testing,
+          # which causes problems.
+          streaming-commons =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.streaming-commons;
+
+          # With nixpkgs-23.11 and our dependency overrides, swagger2 wants hspec for testing,
+          # which causes problems. Also, we jailbreak to allow a newer version of lens.
+          swagger2 =
+            pkgsNew.haskell.lib.dontCheck
+              (pkgsNew.haskell.lib.doJailbreak haskellPackagesOld.swagger2);
+
+          # With nixpkgs-23.11 and ghc981, reflection indirectly depends on hspec for testing,
+          # which causes problems.
+          reflection =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.reflection;
+
+          # With nixpkgs-23.11 and ghc981, resourceat wants hspec for testing,
+          # which causes problems.
+          resourceat =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.resourceat;
+
+          # With nixpkgs-23.11 and ghc981, resourcet wants hspec for testing,
+          # which causes problems.
+          resourcet =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.resourcet;
+
+          # With nixpkgs-23.11 and ghc981, tasty-discover wants hspec for testing,
+          # which causes problems.
+          tasty-discover =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.tasty-discover;
+
+          # Suppress:
+          #   warning: non-portable path to file '"dist/build/Test/autogen/cabal_macros.h"'; specified path differs in case from file name on disk [-Wnonportable-include-path]
+          tasty-golden =
+            pkgsNew.haskell.lib.appendConfigureFlags haskellPackagesOld.tasty-golden
+              [ "--ghc-option=-Wno-nonportable-include-path" ];
+
+          # With nixpkgs-23.11 and ghc981, text-metrics wants hspec for testing,
+          # which causes problems.
+          text-metrics =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.text-metrics;
+
+          # With nixpkgs-23.11 and ghc981, th-compat wants hspec for testing,
+          # which causes problems.
+          th-compat =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.th-compat;
+
+          # With nixpkgs-23.11 and our overrides, th-lift thinks that th-abstraction is out of bounds.
+          th-lift =
+            pkgsNew.haskell.lib.doJailbreak haskellPackagesOld.th-lift;
+
+          # With nixpkgs-23.11 and ghc981, unix-compat wants hspec for testing,
+          # which causes problems.
+          unix-compat =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.unix-compat;
+
+          # With nixpkgs-23.11 and ghc981, hpack-0.36.0 wants hspec for testing,
+          # which causes problems.
+          unix-time =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.unix-time;
+
+          # With nixpkgs-23.11 and ghc981, yaml wants hspec for testing,
+          # which causes problems.
+          yaml =
+            pkgsNew.haskell.lib.dontCheck haskellPackagesOld.yaml;
+
           range-set-list =
             pkgsNew.haskell.lib.overrideCabal
               haskellPackagesOld.range-set-list
@@ -34,15 +279,19 @@ in {
                 jailbreak = true;
               });
 
+          # With nixpkgs-23.11 and ghc962, proto3-wire thinks
+          # that doctest and transformers are out of bounds.
           proto3-wire =
             let
               source = pkgsNew.fetchFromGitHub {
                 owner = "awakesecurity";
                 repo = "proto3-wire";
-                rev = "938523213d5de2d0ad9ece051d1a03002ee539cc";
-                sha256 = "GVH3N1KrFUVpR8ZRkjZcRp51VgMtSXqClL88dM7FBdc=";
+                rev = "b3d837f66d97f97f1ad46c5bb0f1d1bb3b7b13c1"; # 1.4.2
+                sha256 = "LXinRHg7fjBf9of7pDm/oWAacCwJ9x/PtnJz6S0W/FA=";
               };
-            in haskellPackagesNew.callCabal2nix "proto3-wire" source { };
+            in
+              pkgsNew.haskell.lib.doJailbreak
+                (haskellPackagesNew.callCabal2nix "proto3-wire" source { });
 
           proto3-suite-base =
             let

--- a/nix/packages/aeson.nix
+++ b/nix/packages/aeson.nix
@@ -1,0 +1,38 @@
+{ mkDerivation, attoparsec, base, base-compat
+, base-compat-batteries, base-orphans, base16-bytestring
+, bytestring, containers, data-fix, deepseq, Diff, directory, dlist
+, exceptions, filepath, generic-deriving, generically, ghc-prim
+, hashable, indexed-traversable, integer-logarithms, lib, OneTuple
+, primitive, QuickCheck, quickcheck-instances, scientific
+, semialign, strict, tagged, tasty, tasty-golden, tasty-hunit
+, tasty-quickcheck, template-haskell, text, text-short
+, th-abstraction, these, time, time-compat, unordered-containers
+, uuid-types, vector, witherable
+}:
+mkDerivation {
+  pname = "aeson";
+  version = "2.1.2.1";
+  sha256 = "5d4042b903ce181ee023bbf908f37a3f55e820c5f0df102683b87f963e3522c6";
+  revision = "3";
+  editedCabalFile = "19qj4s625b34kw8ryb2ji0hs6dg2m116x913s722bab316k653av";
+  libraryHaskellDepends = [
+    attoparsec base base-compat-batteries bytestring containers
+    data-fix deepseq dlist exceptions generically ghc-prim hashable
+    indexed-traversable OneTuple primitive QuickCheck scientific
+    semialign strict tagged template-haskell text text-short
+    th-abstraction these time time-compat unordered-containers
+    uuid-types vector witherable
+  ];
+  testHaskellDepends = [
+    attoparsec base base-compat base-orphans base16-bytestring
+    bytestring containers data-fix Diff directory dlist filepath
+    generic-deriving generically ghc-prim hashable indexed-traversable
+    integer-logarithms OneTuple primitive QuickCheck
+    quickcheck-instances scientific strict tagged tasty tasty-golden
+    tasty-hunit tasty-quickcheck template-haskell text text-short these
+    time time-compat unordered-containers uuid-types vector
+  ];
+  homepage = "https://github.com/haskell/aeson";
+  description = "Fast JSON parsing and encoding";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/attoparsec-aeson.nix
+++ b/nix/packages/attoparsec-aeson.nix
@@ -1,0 +1,11 @@
+{ mkDerivation, aeson, base, lib }:
+mkDerivation {
+  pname = "attoparsec-aeson";
+  version = "2.1.0.0";
+  sha256 = "b34afb1c330428d9ff7e9e99655ece826ed7a1928dd5880c8127e73a12e906a9";
+  libraryHaskellDepends = [ aeson base ];
+  doHaddock = false;
+  homepage = "https://github.com/haskell/aeson";
+  description = "Parsing of aeson's Value with attoparsec";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/bifunctors.nix
+++ b/nix/packages/bifunctors.nix
@@ -1,0 +1,22 @@
+{ mkDerivation, assoc, base, comonad, containers
+, foldable1-classes-compat, hspec, hspec-discover, lib, QuickCheck
+, tagged, template-haskell, th-abstraction, transformers
+, transformers-compat
+}:
+mkDerivation {
+  pname = "bifunctors";
+  version = "5.6.2";
+  sha256 = "1086a9285061eed0c2c5d3cb65aa223defd52fca6d0515bb69ddf2dbc3d9697a";
+  libraryHaskellDepends = [
+    assoc base comonad containers foldable1-classes-compat tagged
+    template-haskell th-abstraction transformers
+  ];
+  testHaskellDepends = [
+    base hspec QuickCheck template-haskell transformers
+    transformers-compat
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "http://github.com/ekmett/bifunctors/";
+  description = "Bifunctors";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/cborg.nix
+++ b/nix/packages/cborg.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, aeson, array, base, base-orphans, base16-bytestring
+, base64-bytestring, bytestring, containers, deepseq, ghc-bignum
+, ghc-prim, half, lib, primitive, QuickCheck, random, scientific
+, tasty, tasty-hunit, tasty-quickcheck, text, vector
+}:
+mkDerivation {
+  pname = "cborg";
+  version = "0.2.10.0";
+  sha256 = "17fe070c38fc498cab49bcb9d6215b7747d53bedf96502e9bcce9cad73b9c797";
+  libraryHaskellDepends = [
+    array base bytestring containers deepseq ghc-bignum ghc-prim half
+    primitive text
+  ];
+  testHaskellDepends = [
+    aeson array base base-orphans base16-bytestring base64-bytestring
+    bytestring deepseq half primitive QuickCheck random scientific
+    tasty tasty-hunit tasty-quickcheck text vector
+  ];
+  description = "Concise Binary Object Representation (CBOR)";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/crypton.nix
+++ b/nix/packages/crypton.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, base, basement, bytestring, deepseq, gauge
+, ghc-prim, integer-gmp, lib, memory, random, tasty, tasty-hunit
+, tasty-kat, tasty-quickcheck
+}:
+mkDerivation {
+  pname = "crypton";
+  version = "0.34";
+  sha256 = "4444846924ca55615fce104913a5a68675a180cfeadc350ab2b124fba1bc1ed6";
+  libraryHaskellDepends = [
+    base basement bytestring deepseq ghc-prim integer-gmp memory
+  ];
+  testHaskellDepends = [
+    base bytestring memory tasty tasty-hunit tasty-kat tasty-quickcheck
+  ];
+  benchmarkHaskellDepends = [
+    base bytestring deepseq gauge memory random
+  ];
+  homepage = "https://github.com/kazu-yamamoto/crypton";
+  description = "Cryptography Primitives sink";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/doctest.nix
+++ b/nix/packages/doctest.nix
@@ -1,0 +1,30 @@
+{ mkDerivation, base, code-page, deepseq, directory, exceptions
+, filepath, ghc, ghc-paths, hspec, hspec-core, hspec-discover
+, HUnit, lib, mockery, process, QuickCheck, setenv, silently
+, stringbuilder, syb, transformers
+}:
+mkDerivation {
+  pname = "doctest";
+  version = "0.22.2";
+  sha256 = "afb839c14019c17e3ec7900871a9fc104226028858c724932d53225ae382c6e5";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base code-page deepseq directory exceptions filepath ghc ghc-paths
+    process syb transformers
+  ];
+  executableHaskellDepends = [
+    base code-page deepseq directory exceptions filepath ghc ghc-paths
+    process syb transformers
+  ];
+  testHaskellDepends = [
+    base code-page deepseq directory exceptions filepath ghc ghc-paths
+    hspec hspec-core HUnit mockery process QuickCheck setenv silently
+    stringbuilder syb transformers
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://github.com/sol/doctest#readme";
+  description = "Test interactive Haskell examples";
+  license = lib.licenses.mit;
+  mainProgram = "doctest";
+}

--- a/nix/packages/free.nix
+++ b/nix/packages/free.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, comonad, containers, distributive, exceptions
+, indexed-traversable, lib, mtl, profunctors, semigroupoids
+, template-haskell, th-abstraction, transformers, transformers-base
+}:
+mkDerivation {
+  pname = "free";
+  version = "5.2";
+  sha256 = "72867f7c89173263765736e8d395e94291f1aaea626ecb1d673d72ce90b94f89";
+  revision = "4";
+  editedCabalFile = "0vic3p2viip8gjww8fx19ax6ry7y34h7xclvhzkvmbspjh9d219x";
+  libraryHaskellDepends = [
+    base comonad containers distributive exceptions indexed-traversable
+    mtl profunctors semigroupoids template-haskell th-abstraction
+    transformers transformers-base
+  ];
+  homepage = "http://github.com/ekmett/free/";
+  description = "Monads for free";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/generics-sop.nix
+++ b/nix/packages/generics-sop.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, base, criterion, deepseq, ghc-prim, lib, sop-core
+, template-haskell, th-abstraction
+}:
+mkDerivation {
+  pname = "generics-sop";
+  version = "0.5.1.4";
+  sha256 = "616a1c2176097469f9514e76d979fffdbc12d569f44fd01deb14377c7888797e";
+  libraryHaskellDepends = [
+    base ghc-prim sop-core template-haskell th-abstraction
+  ];
+  testHaskellDepends = [ base ];
+  benchmarkHaskellDepends = [
+    base criterion deepseq template-haskell
+  ];
+  description = "Generic Programming using True Sums of Products";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/hedgehog.nix
+++ b/nix/packages/hedgehog.nix
@@ -1,0 +1,27 @@
+{ mkDerivation, ansi-terminal, async, barbies, base, bytestring
+, concurrent-output, containers, deepseq, directory, erf
+, exceptions, lib, lifted-async, mmorph, monad-control, mtl
+, pretty-show, primitive, random, resourcet, safe-exceptions, stm
+, template-haskell, text, time, transformers, transformers-base
+, wl-pprint-annotated
+}:
+mkDerivation {
+  pname = "hedgehog";
+  version = "1.4";
+  sha256 = "f54afb31552e0f809030becad349cbfe19a65753a778771dc7314b2a6c41e6eb";
+  revision = "5";
+  editedCabalFile = "1majbvnqywyqfzm7qm7bhwmfzi3jamiz7d5ql4yvzsix8wg4rbag";
+  libraryHaskellDepends = [
+    ansi-terminal async barbies base bytestring concurrent-output
+    containers deepseq directory erf exceptions lifted-async mmorph
+    monad-control mtl pretty-show primitive random resourcet
+    safe-exceptions stm template-haskell text time transformers
+    transformers-base wl-pprint-annotated
+  ];
+  testHaskellDepends = [
+    base containers mmorph mtl pretty-show text transformers
+  ];
+  homepage = "https://hedgehog.qa";
+  description = "Release with confidence";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/hpack.nix
+++ b/nix/packages/hpack.nix
@@ -1,0 +1,40 @@
+{ mkDerivation, aeson, base, bifunctors, bytestring, Cabal
+, containers, crypton, deepseq, directory, filepath, Glob, hspec
+, hspec-discover, http-client, http-client-tls, http-types, HUnit
+, infer-license, interpolate, lib, mockery, mtl, pretty, QuickCheck
+, scientific, template-haskell, temporary, text, transformers
+, unordered-containers, vector, yaml
+}:
+mkDerivation {
+  pname = "hpack";
+  version = "0.36.0";
+  sha256 = "a0de4e1a0fe587030fa643cad99cd96de81e295923ffb57cfc7b1575f253ea7a";
+  revision = "1";
+  editedCabalFile = "1zh5rsf38xmwp7lf80iifrhnkl80lri4xzlhz2n5df3vc0dqzya8";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    aeson base bifunctors bytestring Cabal containers crypton deepseq
+    directory filepath Glob http-client http-client-tls http-types
+    infer-license mtl pretty scientific text transformers
+    unordered-containers vector yaml
+  ];
+  executableHaskellDepends = [
+    aeson base bifunctors bytestring Cabal containers crypton deepseq
+    directory filepath Glob http-client http-client-tls http-types
+    infer-license mtl pretty scientific text transformers
+    unordered-containers vector yaml
+  ];
+  testHaskellDepends = [
+    aeson base bifunctors bytestring Cabal containers crypton deepseq
+    directory filepath Glob hspec http-client http-client-tls
+    http-types HUnit infer-license interpolate mockery mtl pretty
+    QuickCheck scientific template-haskell temporary text transformers
+    unordered-containers vector yaml
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://github.com/sol/hpack#readme";
+  description = "A modern format for Haskell packages";
+  license = lib.licenses.mit;
+  mainProgram = "hpack";
+}

--- a/nix/packages/http-client-tls.nix
+++ b/nix/packages/http-client-tls.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, base, bytestring, case-insensitive, containers
+, crypton, crypton-connection, data-default-class, exceptions
+, gauge, hspec, http-client, http-types, lib, memory, network
+, network-uri, text, tls, transformers
+}:
+mkDerivation {
+  pname = "http-client-tls";
+  version = "0.3.6.3";
+  sha256 = "38dcfc3d772eb6898b4a8856d6159824d13f65eb291733619f625a802dad9095";
+  libraryHaskellDepends = [
+    base bytestring case-insensitive containers crypton
+    crypton-connection data-default-class exceptions http-client
+    http-types memory network network-uri text tls transformers
+  ];
+  testHaskellDepends = [
+    base crypton-connection hspec http-client http-types
+  ];
+  benchmarkHaskellDepends = [ base gauge http-client ];
+  doCheck = false;
+  homepage = "https://github.com/snoyberg/http-client";
+  description = "http-client backend using the connection package and tls library";
+  license = lib.licenses.mit;
+}

--- a/nix/packages/insert-ordered-containers.nix
+++ b/nix/packages/insert-ordered-containers.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, aeson, base, base-compat, deepseq, hashable
+, indexed-traversable, lens, lib, optics-core, optics-extra
+, QuickCheck, semigroupoids, tasty, tasty-quickcheck, text
+, transformers, unordered-containers
+}:
+mkDerivation {
+  pname = "insert-ordered-containers";
+  version = "0.2.5.3";
+  sha256 = "f04f6e59795d8e362d15422a62d7c7c48312c2d97d2bc4372002a8a9b9a2436c";
+  revision = "1";
+  editedCabalFile = "12fkswr70fw2av11yy45v189r6cb8fcg0l1r7mayvwha3gls0j3n";
+  libraryHaskellDepends = [
+    aeson base deepseq hashable indexed-traversable lens optics-core
+    optics-extra semigroupoids text transformers unordered-containers
+  ];
+  testHaskellDepends = [
+    aeson base base-compat hashable lens QuickCheck semigroupoids tasty
+    tasty-quickcheck text unordered-containers
+  ];
+  homepage = "https://github.com/phadej/insert-ordered-containers#readme";
+  description = "Associative containers retaining insertion order for traversals";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/large-generics.nix
+++ b/nix/packages/large-generics.nix
@@ -6,6 +6,8 @@ mkDerivation {
   pname = "large-generics";
   version = "0.2.1";
   sha256 = "3f50991fa9504d5269a4db89548e25c5d969511951ba5adbd60e00125490632b";
+  revision = "1";
+  editedCabalFile = "0j2dmwf0ccggs25npzrrvz6zpachdbywn2crdlyl1dim3m6psrrh";
   libraryHaskellDepends = [
     aeson base deepseq generics-sop primitive sop-core
   ];

--- a/nix/packages/large-records.nix
+++ b/nix/packages/large-records.nix
@@ -7,6 +7,8 @@ mkDerivation {
   pname = "large-records";
   version = "0.4";
   sha256 = "de51d5f473ca9e57b818221e9bf776e6f68ca90e5cbca1171dc14ce690a7093c";
+  revision = "1";
+  editedCabalFile = "0wcw9rnp2mkchq2xccsyiqqncxq09lj0nyk661a8xpggflsjbhwb";
   libraryHaskellDepends = [
     base containers ghc large-generics mtl primitive
     record-dot-preprocessor record-hasfield syb template-haskell

--- a/nix/packages/lens.nix
+++ b/nix/packages/lens.nix
@@ -1,0 +1,37 @@
+{ mkDerivation, array, assoc, base, base-orphans, bifunctors
+, bytestring, call-stack, comonad, containers, contravariant
+, criterion, deepseq, distributive, exceptions, filepath, free
+, generic-deriving, ghc-prim, hashable, HUnit, indexed-traversable
+, indexed-traversable-instances, kan-extensions, lib, mtl, parallel
+, profunctors, QuickCheck, reflection, semigroupoids
+, simple-reflect, strict, tagged, template-haskell, test-framework
+, test-framework-hunit, test-framework-quickcheck2, text
+, th-abstraction, these, transformers, transformers-compat
+, unordered-containers, vector
+}:
+mkDerivation {
+  pname = "lens";
+  version = "5.3.1";
+  sha256 = "dac3ff7abd483ef36956882631fdcde922e086b51f459c0c02e690c6b7f24b6c";
+  libraryHaskellDepends = [
+    array assoc base base-orphans bifunctors bytestring call-stack
+    comonad containers contravariant distributive exceptions filepath
+    free ghc-prim hashable indexed-traversable
+    indexed-traversable-instances kan-extensions mtl parallel
+    profunctors reflection semigroupoids strict tagged template-haskell
+    text th-abstraction these transformers transformers-compat
+    unordered-containers vector
+  ];
+  testHaskellDepends = [
+    base bytestring containers deepseq HUnit mtl QuickCheck
+    simple-reflect test-framework test-framework-hunit
+    test-framework-quickcheck2 text transformers
+  ];
+  benchmarkHaskellDepends = [
+    base bytestring comonad containers criterion deepseq
+    generic-deriving transformers unordered-containers vector
+  ];
+  homepage = "http://github.com/ekmett/lens/";
+  description = "Lenses, Folds and Traversals";
+  license = lib.licenses.bsd2;
+}

--- a/nix/packages/megaparsec.nix
+++ b/nix/packages/megaparsec.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, bytestring, case-insensitive, containers
+, criterion, deepseq, lib, mtl, parser-combinators, scientific
+, text, transformers, weigh
+}:
+mkDerivation {
+  pname = "megaparsec";
+  version = "9.6.1";
+  sha256 = "a32257be847dbe71ac22d512ab115f9ce26fa08bcdbea7ca8b5256a1700dcbff";
+  libraryHaskellDepends = [
+    base bytestring case-insensitive containers deepseq mtl
+    parser-combinators scientific text transformers
+  ];
+  benchmarkHaskellDepends = [
+    base bytestring containers criterion deepseq text weigh
+  ];
+  homepage = "https://github.com/mrkkrp/megaparsec";
+  description = "Monadic parser combinators";
+  license = lib.licenses.bsd2;
+}

--- a/nix/packages/optics-extra.nix
+++ b/nix/packages/optics-extra.nix
@@ -1,0 +1,18 @@
+{ mkDerivation, array, base, bytestring, containers, hashable
+, indexed-profunctors, indexed-traversable-instances, lib, mtl
+, optics-core, text, transformers, unordered-containers, vector
+}:
+mkDerivation {
+  pname = "optics-extra";
+  version = "0.4.2.1";
+  sha256 = "7e23a7a325e3448354614d3d958279c9ac2fdd0831ceee2808830e7a962fca41";
+  revision = "2";
+  editedCabalFile = "0w7am7pvwg4mx0nrksxgr2rvnk99nhqfpj80ig21m9xbpxsh22x4";
+  libraryHaskellDepends = [
+    array base bytestring containers hashable indexed-profunctors
+    indexed-traversable-instances mtl optics-core text transformers
+    unordered-containers vector
+  ];
+  description = "Extra utilities and instances for optics-core";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/optics-th.nix
+++ b/nix/packages/optics-th.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, base, containers, lib, mtl, optics-core, tagged
+, template-haskell, th-abstraction, transformers
+}:
+mkDerivation {
+  pname = "optics-th";
+  version = "0.4.1";
+  sha256 = "d73857b79dcd8f7c7e70fa4727f134145b62902e8d3e448f8b25c38a9da4fd17";
+  revision = "7";
+  editedCabalFile = "1zlx9xs8dpr3xbxsbi7pgrqkl6avs4ss2bdq8f3p2dxibr8xi4bz";
+  libraryHaskellDepends = [
+    base containers mtl optics-core template-haskell th-abstraction
+    transformers
+  ];
+  testHaskellDepends = [ base optics-core tagged ];
+  description = "Optics construction using TemplateHaskell";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/optparse-generic.nix
+++ b/nix/packages/optparse-generic.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, base, bytestring, filepath, lib, Only
+, optparse-applicative, text, time, transformers
+, transformers-compat, void
+}:
+mkDerivation {
+  pname = "optparse-generic";
+  version = "1.5.2";
+  sha256 = "c7b451f32d34124aab838fadaab4cf2e271e558ddc13a702458b6c790a2e8a35";
+  revision = "1";
+  editedCabalFile = "190nlp7dh878232ia2nsl75q6bzr62szl1vcyinz528lmdbnbpdc";
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base bytestring filepath Only optparse-applicative text time
+    transformers transformers-compat void
+  ];
+  executableHaskellDepends = [ base ];
+  description = "Auto-generate a command-line parser for your datatype";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/parsec-class.nix
+++ b/nix/packages/parsec-class.nix
@@ -1,0 +1,10 @@
+{ mkDerivation, base, lib, parsec }:
+mkDerivation {
+  pname = "parsec-class";
+  version = "1.0.1.0";
+  sha256 = "068686c03627ffca77128a762de295c4a43095b9e8dbe3829efc91fed00c418c";
+  libraryHaskellDepends = [ base parsec ];
+  homepage = "https://github.com/peti/parsec-class";
+  description = "Class of types that can be constructed from their text representation";
+  license = lib.licenses.mit;
+}

--- a/nix/packages/rebase.nix
+++ b/nix/packages/rebase.nix
@@ -1,0 +1,20 @@
+{ mkDerivation, base, bifunctors, bytestring, comonad, containers
+, contravariant, deepseq, dlist, either, groups, hashable
+, invariant, lib, mtl, profunctors, scientific, selective
+, semigroupoids, stm, text, time, time-compat, transformers
+, unordered-containers, uuid-types, vector, vector-instances, void
+}:
+mkDerivation {
+  pname = "rebase";
+  version = "1.20.2";
+  sha256 = "001297a891f30c51fa7f95d97fbb6e47c8dd4a7f13ddb371d5b5780fca7bbb92";
+  libraryHaskellDepends = [
+    base bifunctors bytestring comonad containers contravariant deepseq
+    dlist either groups hashable invariant mtl profunctors scientific
+    selective semigroupoids stm text time time-compat transformers
+    unordered-containers uuid-types vector vector-instances void
+  ];
+  homepage = "https://github.com/nikita-volkov/rebase";
+  description = "A more progressive alternative to the \"base\" package";
+  license = lib.licenses.mit;
+}

--- a/nix/packages/record-dot-preprocessor.nix
+++ b/nix/packages/record-dot-preprocessor.nix
@@ -3,8 +3,8 @@
 }:
 mkDerivation {
   pname = "record-dot-preprocessor";
-  version = "0.2.16";
-  sha256 = "2c067163a6308a61e65f88e168558ac5062e41b86cad9346898bdd77e72b1a80";
+  version = "0.2.17";
+  sha256 = "c614e29522951a518b3257cfebb990aecdf76c4440315247e4652573121ddf4d";
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [ base extra ghc uniplate ];
@@ -13,4 +13,5 @@ mkDerivation {
   homepage = "https://github.com/ndmitchell/record-dot-preprocessor#readme";
   description = "Preprocessor to allow record.field syntax";
   license = lib.licenses.bsd3;
+  mainProgram = "record-dot-preprocessor";
 }

--- a/nix/packages/semigroupoids.nix
+++ b/nix/packages/semigroupoids.nix
@@ -1,0 +1,19 @@
+{ mkDerivation, base, base-orphans, bifunctors, comonad, containers
+, contravariant, distributive, foldable1-classes-compat, hashable
+, lib, tagged, template-haskell, transformers, transformers-compat
+, unordered-containers
+}:
+mkDerivation {
+  pname = "semigroupoids";
+  version = "6.0.1";
+  sha256 = "1d532030862414f5d4f2f6f001783f77aa14e5f05ee8e3c4a2d2129fca29cc1f";
+  libraryHaskellDepends = [
+    base base-orphans bifunctors comonad containers contravariant
+    distributive foldable1-classes-compat hashable tagged
+    template-haskell transformers transformers-compat
+    unordered-containers
+  ];
+  homepage = "http://github.com/ekmett/semigroupoids";
+  description = "Semigroupoids: Category sans id";
+  license = lib.licenses.bsd2;
+}

--- a/nix/packages/serialise.nix
+++ b/nix/packages/serialise.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, aeson, array, base, binary, bytestring, cborg
+, cereal, cereal-vector, containers, criterion, deepseq, directory
+, fail, filepath, ghc-prim, half, hashable, lib, pretty, primitive
+, QuickCheck, quickcheck-instances, semigroups, store, strict, tar
+, tasty, tasty-hunit, tasty-quickcheck, text, these, time
+, unordered-containers, vector, zlib
+}:
+mkDerivation {
+  pname = "serialise";
+  version = "0.2.6.1";
+  sha256 = "63949799ffd10675ef70ea701c1eb63e618629b3b2f7b25f07c5a966e24e77f4";
+  revision = "2";
+  editedCabalFile = "1y21m10vx4k75x0im5448pl5mhl772hz1hfk47ryb3whz1l6d9vf";
+  libraryHaskellDepends = [
+    array base bytestring cborg containers ghc-prim half hashable
+    primitive strict text these time unordered-containers vector
+  ];
+  testHaskellDepends = [
+    base bytestring cborg containers directory filepath primitive
+    QuickCheck quickcheck-instances tasty tasty-hunit tasty-quickcheck
+    text time unordered-containers vector
+  ];
+  benchmarkHaskellDepends = [
+    aeson array base binary bytestring cborg cereal cereal-vector
+    containers criterion deepseq directory fail filepath ghc-prim half
+    pretty semigroups store tar text time vector zlib
+  ];
+  homepage = "https://github.com/well-typed/cborg";
+  description = "A binary serialisation library for Haskell values";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/singleton-bool.nix
+++ b/nix/packages/singleton-bool.nix
@@ -1,0 +1,12 @@
+{ mkDerivation, base, boring, dec, deepseq, lib, some }:
+mkDerivation {
+  pname = "singleton-bool";
+  version = "0.1.7";
+  sha256 = "1c2d196386c3697e884fcc8bef530506045a4860a5f669cc8416358b473bb29b";
+  revision = "1";
+  editedCabalFile = "1aqdd1bzccj8fb2fy1la9gqxvgaa2prba4wig0bnrr5vz13f487c";
+  libraryHaskellDepends = [ base boring dec deepseq some ];
+  homepage = "https://github.com/phadej/singleton-bool#readme";
+  description = "Type level booleans";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/some.nix
+++ b/nix/packages/some.nix
@@ -1,0 +1,11 @@
+{ mkDerivation, base, base-orphans, deepseq, lib }:
+mkDerivation {
+  pname = "some";
+  version = "1.0.6";
+  sha256 = "f7a606ad5df4a07459986364f7d739eb653495fbbe1d7158582fb29a4584bfb9";
+  libraryHaskellDepends = [ base base-orphans deepseq ];
+  testHaskellDepends = [ base ];
+  homepage = "https://github.com/haskellari/some";
+  description = "Existential type: Some";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/swagger2.nix
+++ b/nix/packages/swagger2.nix
@@ -1,0 +1,31 @@
+{ mkDerivation, aeson, aeson-pretty, base, base-compat-batteries
+, bytestring, Cabal, cabal-doctest, containers, cookie, doctest
+, generics-sop, Glob, hashable, hspec, hspec-discover, http-media
+, HUnit, insert-ordered-containers, lens, lib, mtl, network
+, optics-core, optics-th, QuickCheck, quickcheck-instances
+, scientific, template-haskell, text, time, transformers
+, unordered-containers, utf8-string, uuid-types, vector
+}:
+mkDerivation {
+  pname = "swagger2";
+  version = "2.8.8";
+  sha256 = "efbfda9ea97276ecfbcb73d79e56cc56efc05af2b35bb7444fceb497e7eb79f3";
+  setupHaskellDepends = [ base Cabal cabal-doctest ];
+  libraryHaskellDepends = [
+    aeson aeson-pretty base base-compat-batteries bytestring containers
+    cookie generics-sop hashable http-media insert-ordered-containers
+    lens mtl network optics-core optics-th QuickCheck scientific
+    template-haskell text time transformers unordered-containers
+    uuid-types vector
+  ];
+  testHaskellDepends = [
+    aeson base base-compat-batteries bytestring containers doctest Glob
+    hashable hspec HUnit insert-ordered-containers lens mtl QuickCheck
+    quickcheck-instances template-haskell text time
+    unordered-containers utf8-string vector
+  ];
+  testToolDepends = [ hspec-discover ];
+  homepage = "https://github.com/GetShopTV/swagger2";
+  description = "Swagger 2.0 data model";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/tagged.nix
+++ b/nix/packages/tagged.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, base, deepseq, lib, template-haskell, transformers
+}:
+mkDerivation {
+  pname = "tagged";
+  version = "0.8.8";
+  sha256 = "a083fa7835516203c168433a1c8dfc0290a94b05fedab566ad0640fc9137a6a7";
+  revision = "1";
+  editedCabalFile = "0chbxdppgpsrjqzf28z53x9wqwz0ncfimhfc6rr9knixvvxxx4wi";
+  libraryHaskellDepends = [
+    base deepseq template-haskell transformers
+  ];
+  homepage = "http://github.com/ekmett/tagged";
+  description = "Haskell 98 phantom types to avoid unsafely passing dummy arguments";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/tasty-hedgehog.nix
+++ b/nix/packages/tasty-hedgehog.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, base, hedgehog, lib, tagged, tasty
+, tasty-expected-failure
+}:
+mkDerivation {
+  pname = "tasty-hedgehog";
+  version = "1.4.0.2";
+  sha256 = "453484d732712525a9c74a07db5f18b5f80f867a98958e67031d8d0bfe007152";
+  revision = "3";
+  editedCabalFile = "1ij1h7kdbg4bd93fl9991b39xn1rkawshsh3hgbz3j2inmnljx2w";
+  libraryHaskellDepends = [ base hedgehog tagged tasty ];
+  testHaskellDepends = [
+    base hedgehog tasty tasty-expected-failure
+  ];
+  homepage = "https://github.com/qfpl/tasty-hedgehog";
+  description = "Integration for tasty and hedgehog";
+  license = lib.licenses.bsd3;
+}

--- a/nix/packages/th-abstraction.nix
+++ b/nix/packages/th-abstraction.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, containers, ghc-prim, lib, template-haskell
+}:
+mkDerivation {
+  pname = "th-abstraction";
+  version = "0.7.0.0";
+  sha256 = "b2854c612f2fa4adfa1ecbb4089a2211fd9cb3210aec17ba4a455ae486b22721";
+  libraryHaskellDepends = [
+    base containers ghc-prim template-haskell
+  ];
+  testHaskellDepends = [ base containers template-haskell ];
+  homepage = "https://github.com/glguy/th-abstraction";
+  description = "Nicer interface for reified information about data types";
+  license = lib.licenses.isc;
+}

--- a/nix/packages/turtle.nix
+++ b/nix/packages/turtle.nix
@@ -6,8 +6,10 @@
 }:
 mkDerivation {
   pname = "turtle";
-  version = "1.6.1";
-  sha256 = "2795445c93a4b646dd02b68ebf4006f8ec3588c85ccfe9d47810597e638e3b9c";
+  version = "1.6.2";
+  sha256 = "1a0166b11566e956bcec6f37cfcfc4d0647d4540479545d4858d2ff8c43a5b2d";
+  revision = "2";
+  editedCabalFile = "14jnb2vyq0nx4cp4c97xflzg7z9xw1avg2d27c1d1cnqg28pd4an";
   libraryHaskellDepends = [
     ansi-wl-pprint async base bytestring clock containers directory
     exceptions filepath foldl hostname managed optional-args

--- a/nix/patches/aeson-2.1.2.1.patch
+++ b/nix/patches/aeson-2.1.2.1.patch
@@ -1,0 +1,11 @@
+--- a/src/Data/Aeson/Internal/Text.hs	2001-09-08 18:46:40.000000000 -0700
++++ b/src/Data/Aeson/Internal/Text.hs	2024-05-09 21:16:49.964743729 -0700
+@@ -8,5 +8,5 @@
+ import qualified Data.Text                      as T
+
+ #if MIN_VERSION_text(2,0,0)
+-import           Data.Text.Array                (Array (..))
++import           Data.Text.Array
+ import qualified Data.Text.Internal             as T (Text (..))
+
+ import qualified Data.ByteString.Short.Internal as SBS

--- a/proto3-suite.cabal
+++ b/proto3-suite.cabal
@@ -105,8 +105,8 @@ library
                        base >=4.8 && <5.0,
                        base64-bytestring >= 1.0.0.1 && < 1.3,
                        binary >=0.8.3,
-                       bytestring >=0.10.6.0 && <0.12.0,
-                       deepseq ==1.4.*,
+                       bytestring >= 0.10.6.0 && < 0.13,
+                       deepseq >= 1.4 && < 1.6,
                        cereal >= 0.5.1 && <0.6,
                        containers >=0.5 && < 0.7,
                        contravariant >=1.4 && <1.6,
@@ -116,7 +116,7 @@ library
                        haskell-src ==1.0.*,
                        insert-ordered-containers,
                        lens,
-                       mtl ==2.2.*,
+                       mtl >= 2.2 && < 2.4,
                        neat-interpolation,
                        parsec >= 3.1.9 && <3.2.0,
                        parsers >= 0.12 && <0.13,
@@ -129,11 +129,11 @@ library
                        split,
                        system-filepath,
                        time,
-                       text >= 0.2 && <2.1,
+                       text >= 0.2 && < 2.2,
                        text-short >=0.1.3 && <0.2,
-                       transformers >=0.4 && <0.6,
+                       transformers >= 0.4 && < 0.7,
                        turtle < 1.6.0 || >= 1.6.1 && < 1.7.0,
-                       vector >=0.11 && < 0.13,
+                       vector >= 0.11 && < 0.14,
                        attoparsec-aeson
   if !impl(ghc >= 8.0)
     build-depends:     semigroups >= 0.18 && < 0.20
@@ -196,14 +196,14 @@ test-suite tests
     , attoparsec >= 0.13.0.1
     , base >=4.8 && <5.0
     , base64-bytestring >= 1.0.0.1 && < 1.3
-    , bytestring >=0.10.6.0 && <0.12.0
+    , bytestring >= 0.10.6.0 && < 0.13.0
     , cereal >= 0.5.1 && <0.6
     , containers >=0.5 && < 0.7
-    , deepseq ==1.4.*
+    , deepseq >= 1.4 && < 1.6
     , doctest
     , generic-arbitrary
     , hedgehog
-    , mtl ==2.2.*
+    , mtl >= 2.2 && < 2.4
     , parsec >= 3.1.9 && <3.2.0
     , pretty ==1.1.*
     , pretty-show >= 1.6.12 && < 2.0
@@ -215,11 +215,11 @@ test-suite tests
     , tasty-hedgehog
     , tasty-hunit >= 0.9 && <0.11
     , tasty-quickcheck >= 0.8.4 && <0.11
-    , text >= 0.2 && <2.1
+    , text >= 0.2 && <2.2
     , text-short >=0.1.3 && <0.2
-    , transformers >=0.4 && <0.6
+    , transformers >= 0.4 && < 0.7
     , turtle
-    , vector >=0.11 && < 0.13
+    , vector >=0.11 && < 0.14
 
   if !impl(ghc >= 8.0)
     build-depends:     semigroups >= 0.18 && < 0.20
@@ -243,7 +243,7 @@ executable canonicalize-proto-file
   default-language:    Haskell2010
   build-depends:       base >=4.11.0.0 && <5.0
                        , containers >=0.5 && <0.7
-                       , mtl ==2.2.*
+                       , mtl >= 2.2 && < 2.4
                        , optparse-generic
                        , proto3-suite
                        , proto3-wire >= 1.2 && <1.5

--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,7 @@
 #   $ nix-shell --arg fast true
 #
 { fast ? false
-, compiler ? "ghc8107"
+, compiler ? "ghc982"
 , enableDhall ? false
 , enableSwagger ? true
 , swaggerWrapperFormat ? false


### PR DESCRIPTION
GHC 9.8 でビルドできるようにするため依存ライブラリーのバージョン範囲を緩和した

GHC 9.8 を Nix で取得するため nixpkgs を更新すると、エラーになったので awakesecurity/master の 800bfa8ddd6e9a32eedca1005560648ba97084cf から必要なファイルをコピーした